### PR TITLE
Fix rollup querybuilder name

### DIFF
--- a/packages/nocodb/src/db/genRollupSelectv2.ts
+++ b/packages/nocodb/src/db/genRollupSelectv2.ts
@@ -123,7 +123,7 @@ export default async function ({
     case RelationTypes.MANY_TO_MANY: {
       if (columnOptions instanceof LinksColumn) {
         try {
-          const qb = knex("nc_tdo8___Obstructions").select(1).first()
+          const qb = knex.queryBuilder().select(1).first()
           return {
             builder: qb,
           };


### PR DESCRIPTION
## Description
We shouldn't use one of the table names to generate a blank query builder. 
This will fix changing the names of columns as when we change a column name, Nocodb also migrates the table from its old name to the new version of names without triple underscore

## Tests
Rollups still work and display one item:
<img width="597" height="71" alt="image" src="https://github.com/user-attachments/assets/31f2668c-fb8b-4952-9cbc-960e05d8bf10" />
